### PR TITLE
remove copying all outputs by default

### DIFF
--- a/src/atomate2/aims/files.py
+++ b/src/atomate2/aims/files.py
@@ -24,7 +24,7 @@ def copy_aims_outputs(
     src_dir: Path | str,
     src_host: str | None = None,
     additional_aims_files: list[str] | None = None,
-    restart_to_input: bool = True,
+    restart_to_input: bool = False,
     file_client: FileClient | None = None,
 ):
     """
@@ -52,15 +52,16 @@ def copy_aims_outputs(
     # additional files like bands, DOS, *.cube, whatever
     additional_files = additional_aims_files if additional_aims_files else []
 
-    if restart_to_input:
-        additional_files += ("hessian.aims", "geometry.in.next_step", "*.csc")
-
     # copy files
-    files: list[str | Path] = ["aims.out", "*.json"]
+    # (no need to copy aims.out by default; it can be added to additional_aims_files
+    # explicitly if needed)
+    files: list[str] = (
+        ["hessian.aims", "geometry.in.next_step", "*.csc"] if restart_to_input else []
+    )
 
     files += [
         Path(f).name
-        for pattern in set(additional_files)
+        for pattern in set(files + additional_files)
         for f in glob((Path(src_dir) / pattern).as_posix())
     ]
 

--- a/src/atomate2/aims/jobs/base.py
+++ b/src/atomate2/aims/jobs/base.py
@@ -14,6 +14,7 @@ from pymatgen.core import Molecule, Structure
 
 from atomate2.aims.files import (
     cleanup_aims_outputs,
+    copy_aims_outputs,
     write_aims_input_set,
 )
 from atomate2.aims.run import run_aims, should_stop_children
@@ -89,9 +90,9 @@ class BaseAimsMaker(Maker):
         else:
             atoms = structure.copy()
 
-        # copy previous inputs
-        # if prev_dir is not None:
-        #     copy_aims_outputs(prev_dir, **self.copy_aims_kwargs)
+        # copy previous inputs if needed (governed by self.copy_aims_kwargs)
+        if prev_dir is not None:
+            copy_aims_outputs(prev_dir, **self.copy_aims_kwargs)
 
         # write aims input files
         self.write_input_set_kwargs["prev_dir"] = prev_dir
@@ -181,7 +182,7 @@ class ConvergenceMaker(Maker):
 
         Parameters
         ----------
-        atoms : .MSONableAtoms or Structure or Molecule
+        structure : .MSONableAtoms or Structure or Molecule
             The structure to run the job for
         prev_dir: str or None
             An FHI-aims calculation directory in which previous run contents are stored

--- a/tests/aims/test_files/test_files.py
+++ b/tests/aims/test_files/test_files.py
@@ -29,7 +29,7 @@ def test_copy_aims_outputs(tmp_dir):
     restart_files = ["geometry.in.next_step", "D_spin_01_kpt_000001.csc"]
 
     path = TEST_DIR / "outputs"
-    copy_aims_outputs(src_dir=path)
+    copy_aims_outputs(src_dir=path, restart_to_input=True, additional_aims_files=files)
 
     for f in files + restart_files:
         assert Path(f).exists()


### PR DESCRIPTION
This PR is just removing copying of all the outputs to the next dir by default and moving this logic to the base maker. When I tried the writing a restart maker, it appeared that there is no way of finding if the previous calculation converged (well, it has to be, or else the ParseError is thrown). So it will need changing the underlined logic of the parser and the base maker, something that I would not want to do without consulting with you first.
